### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. 
+    # (You don't need to specify `/.github/workflows` for `directory`. 
+    # You can use `directory: "/"`.)
+    directory: "/"
+    # Run on first of each month
+    schedule:
+      interval: "monthly"
+    # Group to submit a single PR if possible
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a config to automatically update out-of-date GitHub actions. This ignores actions & workflows referenced locally (meaning manual updates are still necessary for these).